### PR TITLE
feat: Add staging config for Github Actions

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,4 +1,4 @@
-name: Semantic release 
+name: Production 
 
 on:
   push:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,30 @@
+name: Staging 
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  deploy:
+    if: contains(github.event.head_commit.message, 'skip ci') == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: amondnet/now-deployment@v2
+        id: deployment_metadata
+        with:
+          zeit-token: ${{ secrets.ZEIT_TOKEN }} # Required
+          github-token: ${{ secrets.GH_TOKEN }} #Optional 
+          now-org-id: ${{ secrets.NOW_ORG_ID}}  #Required
+          now-project-id: ${{ secrets.NOW_PROJECT_ID}} #Required 
+      - shell: bash
+        env:
+          PREVIEW_URL: ${{ steps.deployment_metadata.outputs.preview-url }}
+        run: |
+          echo $PREVIEW_URL > preview_url.txt
+      - name: Upload preview url from deploy
+        uses: actions/upload-artifact@v1
+        with:
+          name: deployment
+          path: preview_url.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .next
 # Dependency directories
 node_modules
-
+# Now config folder
+.now


### PR DESCRIPTION
- Deploy staging URL when pushing a branch for Continuous Integration (except master branch).
- Upload unique preview URL as an artifact in order to be able to perform e2e testing on it.

Closes #11